### PR TITLE
[POC] Add Watcher's host-maintenance params to sunbeam CLI

### DIFF
--- a/sunbeam-python/sunbeam/features/maintenance/commands.py
+++ b/sunbeam-python/sunbeam/features/maintenance/commands.py
@@ -66,6 +66,18 @@ LOG = logging.getLogger(__name__)
     is_flag=True,
     default=False,
 )
+@click.option(
+    "--disable-live-migration",
+    help="Disable live migration during maintenance",
+    is_flag=True,
+    default=False,
+)
+@click.option(
+    "--disable-cold-migration",
+    help="Disable cold migration during maintenance",
+    is_flag=True,
+    default=False,
+)
 @click_option_show_hints
 @pass_method_obj
 def enable(
@@ -76,6 +88,8 @@ def enable(
     dry_run,
     enable_ceph_crush_rebalancing,
     stop_osds,
+    disable_live_migration,
+    disable_cold_migration,
     show_hints: bool = False,
 ) -> None:
     """Enable maintenance mode for node."""
@@ -131,7 +145,12 @@ def enable(
     generate_operation_plan: list[BaseStep] = []
     if "compute" in node_status:
         generate_operation_plan.append(
-            CreateWatcherHostMaintenanceAuditStep(deployment=deployment, node=node)
+            CreateWatcherHostMaintenanceAuditStep(
+                deployment=deployment,
+                node=node,
+                disable_live_migration=disable_live_migration,
+                disable_cold_migration=disable_cold_migration
+            )
         )
     if "storage" in node_status:
         generate_operation_plan.append(

--- a/sunbeam-python/sunbeam/steps/maintenance.py
+++ b/sunbeam-python/sunbeam/steps/maintenance.py
@@ -116,14 +116,32 @@ class CreateWatcherHostMaintenanceAuditStep(CreateWatcherAuditStepABC):
     name = "Create Watcher Host maintenance audit"
     description = "Create Watcher Host maintenance audit"
 
+    def __init__(
+        self,
+        deployment: Deployment,
+        node: str,
+        disable_live_migration: bool = False,
+        disable_cold_migration: bool = False,
+    ):
+        super().__init__(deployment=deployment, node=node)
+        self.disable_live_migration = disable_live_migration
+        self.disable_cold_migration = disable_cold_migration
+
     def _create_audit(self) -> "watcher.Audit":
         audit_template = watcher_helper.get_enable_maintenance_audit_template(
             client=self.client
         )
+
+        parameters = {
+            "maintenance_node": self.node,
+            "disable_live_migration": self.disable_live_migration,
+            "disable_cold_migration": self.disable_cold_migration,
+        }
+
         return watcher_helper.create_audit(
             client=self.client,
             template=audit_template,
-            parameters={"maintenance_node": self.node},
+            parameters=parameters,
         )
 
 


### PR DESCRIPTION
Add new parameters for Watcher Host Maintenance Strategy as implement [here](https://review.opendev.org/c/openstack/watcher/+/952538) to the Sunbeam CLI.
Example usage:

- Default (Watcher default is to enable both migrations):
```
  sunbeam cluster maintenance enable compute-1 --dry-run
```

- Disable live migration:
```
  sunbeam cluster maintenance enable compute-1 \
    --disable-live-migration \
    --dry-run
```

- Disable cold migration:
```
  sunbeam cluster maintenance enable compute-1 \
    --disable-cold-migration \
    --dry-run
```

- No migration (stop active instances):
```
  sunbeam cluster maintenance enable compute-1 \
    --disable-live-migration \
    --disable-cold-migration \
    --dry-run
```