### PR TITLE
Support `disable-migration` flag for sunbeam host maintenance command

### DIFF
--- a/sunbeam-python/sunbeam/features/maintenance/commands.py
+++ b/sunbeam-python/sunbeam/features/maintenance/commands.py
@@ -111,6 +111,8 @@ class EnableMaintenance(MaintenanceCommand):
         stop_osds: bool = False,
         allow_downtime: bool = False,
         enable_ceph_crush_rebalancing: bool = False,
+        disable_live_migration: bool = False,
+        disable_cold_migration: bool = False,
     ):
         self.node = node
         self.deployment = deployment
@@ -119,6 +121,8 @@ class EnableMaintenance(MaintenanceCommand):
         self.stop_osds = stop_osds
         self.allow_downtime = allow_downtime
         self.enable_ceph_crush_rebalancing = enable_ceph_crush_rebalancing
+        self.disable_live_migration = disable_live_migration
+        self.disable_cold_migration = disable_cold_migration
 
         self.model = deployment.openstack_machines_model
         self.client = deployment.get_client()
@@ -299,6 +303,8 @@ class EnableMaintenance(MaintenanceCommand):
                 CreateWatcherHostMaintenanceAuditStep(
                     deployment=self.deployment,
                     node=self.node,
+                    disable_live_migration=self.disable_live_migration,
+                    disable_cold_migration=self.disable_cold_migration,
                 )
             )
 
@@ -606,6 +612,18 @@ class DisableMaintenance(MaintenanceCommand):
     is_flag=True,
     default=False,
 )
+@click.option(
+    "--disable-migration",
+    help=(
+        "Disable migration during maintenance (both, live, cold)."
+        " If not specified, defaults to Watcher's defaults (both False)"
+        " If specified without value, defaults to 'both' (both True)"
+    ),
+    type=click.Choice(["both", "live", "cold"]),
+    default=None,
+    is_flag=False,
+    flag_value="both",
+)
 @click_option_show_hints
 @pass_method_obj
 def enable(
@@ -617,6 +635,7 @@ def enable(
     enable_ceph_crush_rebalancing,
     stop_osds,
     allow_downtime,
+    disable_migration,
     show_hints: bool = False,
 ) -> None:
     """Enable maintenance mode for node."""
@@ -627,6 +646,14 @@ def enable(
         show_hints=show_hints,
     )
 
+    # Default to Watcher's defaults (both False) when not specified
+    if not disable_migration:
+        disable_live_migration = False
+        disable_cold_migration = False
+    else:
+        disable_live_migration = disable_migration in ["both", "live"]
+        disable_cold_migration = disable_migration in ["both", "cold"]
+
     enable_maintenance = EnableMaintenance(
         node,
         deployment,
@@ -635,6 +662,8 @@ def enable(
         stop_osds=stop_osds,
         allow_downtime=allow_downtime,
         enable_ceph_crush_rebalancing=enable_ceph_crush_rebalancing,
+        disable_live_migration=disable_live_migration,
+        disable_cold_migration=disable_cold_migration,
     )
 
     enable_maintenance(console, show_hints, dry_run)

--- a/sunbeam-python/sunbeam/steps/maintenance.py
+++ b/sunbeam-python/sunbeam/steps/maintenance.py
@@ -121,14 +121,32 @@ class CreateWatcherHostMaintenanceAuditStep(CreateWatcherAuditStepABC):
     name = "Create Watcher Host maintenance audit"
     description = "Create Watcher Host maintenance audit"
 
+    def __init__(
+        self,
+        deployment: Deployment,
+        node: str,
+        disable_live_migration: bool = False,
+        disable_cold_migration: bool = False,
+    ):
+        super().__init__(deployment=deployment, node=node)
+        self.disable_live_migration = disable_live_migration
+        self.disable_cold_migration = disable_cold_migration
+
     def _create_audit(self) -> "watcher.Audit":
         audit_template = watcher_helper.get_enable_maintenance_audit_template(
             client=self.client
         )
+
+        parameters = {
+            "maintenance_node": self.node,
+            "disable_live_migration": self.disable_live_migration,
+            "disable_cold_migration": self.disable_cold_migration,
+        }
+
         return watcher_helper.create_audit(
             client=self.client,
             template=audit_template,
-            parameters={"maintenance_node": self.node},
+            parameters=parameters,
         )
 
 

--- a/sunbeam-python/tests/unit/sunbeam/features/maintenance/test_commands.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/maintenance/test_commands.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: 2026 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from sunbeam.features.maintenance.commands import EnableMaintenance, enable
+
+
+class TestDisableMigrationFlagMapping:
+    """Test the --disable-migration CLI flag to boolean mapping logic.
+
+    This tests the mapping in the enable() Click command that converts
+    --disable-migration choice values to disable_live/cold_migration booleans.
+    """
+
+    @pytest.mark.parametrize(
+        "disable_migration,expected_live,expected_cold",
+        [
+            (None, False, False),  # Not specified
+            ("both", True, True),  # --disable-migration (flag_value default)
+            ("live", True, False),  # --disable-migration live
+            ("cold", False, True),  # --disable-migration cold
+        ],
+    )
+    def test_disable_migration_flag_mapping(
+        self,
+        disable_migration,
+        expected_live,
+        expected_cold,
+    ):
+        """Test --disable-migration maps to correct boolean params."""
+        with (
+            patch(
+                "sunbeam.features.maintenance.commands.EnableMaintenance"
+            ) as mock_cls,
+            patch(
+                "sunbeam.features.maintenance.commands.get_cluster_status"
+            ) as mock_get_status,
+            patch("sunbeam.features.maintenance.commands.JujuHelper"),
+        ):
+            mock_get_status.return_value = {"test-node": "compute"}
+            mock_instance = Mock()
+            mock_cls.return_value = mock_instance
+
+            # enable is wrapped by pass_method_obj which calls
+            # click.get_current_context() to inject deployment.
+            mock_ctx = Mock()
+            mock_ctx.obj = Mock()  # deployment injected by pass_method_obj
+            with patch("click.get_current_context", return_value=mock_ctx):
+                enable.callback(
+                    None,  # self (from pass_method_obj)
+                    node="test-node",
+                    force=False,
+                    dry_run=True,
+                    enable_ceph_crush_rebalancing=False,
+                    stop_osds=False,
+                    allow_downtime=False,
+                    disable_migration=disable_migration,
+                    show_hints=False,
+                )
+
+            # Verify EnableMaintenance was constructed with correct booleans
+            mock_cls.assert_called_once()
+            call_kwargs = mock_cls.call_args[1]
+            assert call_kwargs["disable_live_migration"] == expected_live
+            assert call_kwargs["disable_cold_migration"] == expected_cold
+
+
+class TestEnableMaintenance:
+    """Test cases for the EnableMaintenance class."""
+
+    @pytest.fixture
+    def mock_deployment(self):
+        """Mock deployment object."""
+        deployment = Mock()
+        deployment.openstack_machines_model = "test-model"
+        deployment.get_client.return_value = Mock()
+        deployment.juju_controller = "test-controller"
+        return deployment
+
+    @pytest.fixture
+    def cluster_status(self):
+        """Mock cluster status."""
+        return {"test-node": "compute"}
+
+    @pytest.mark.parametrize(
+        "disable_live_migration,disable_cold_migration",
+        [
+            (False, False),  # Default case
+            (True, True),  # Both disabled
+            (True, False),  # Only live disabled
+            (False, True),  # Only cold disabled
+        ],
+    )
+    def test_dry_run_creates_watcher_step_with_correct_migration_params(
+        self,
+        mock_deployment,
+        cluster_status,
+        disable_live_migration,
+        disable_cold_migration,
+    ):
+        """Test dry_run creates CreateWatcherHostMaintenanceAuditStep correctly."""
+        with (
+            patch(
+                "sunbeam.features.maintenance.commands.CreateWatcherHostMaintenanceAuditStep"
+            ) as mock_create_watcher_step,
+            patch("sunbeam.features.maintenance.commands.run_plan") as mock_run_plan,
+            patch("sunbeam.features.maintenance.commands.JujuHelper"),
+            patch("sunbeam.features.maintenance.commands.OperationViewer"),
+        ):
+            # Set up mock class name for get_step_message
+            mock_create_watcher_step.__name__ = "CreateWatcherHostMaintenanceAuditStep"
+
+            # Mock run_plan return value
+            mock_result = Mock()
+            mock_result.message = {"actions": []}
+            mock_run_plan.return_value = {
+                "CreateWatcherHostMaintenanceAuditStep": mock_result
+            }
+
+            # Create EnableMaintenance instance
+            enable_maintenance = EnableMaintenance(
+                node="test-node",
+                deployment=mock_deployment,
+                cluster_status=cluster_status,
+                disable_live_migration=disable_live_migration,
+                disable_cold_migration=disable_cold_migration,
+            )
+
+            # Mock console for dry_run
+            mock_console = Mock()
+
+            # Call dry_run
+            enable_maintenance.dry_run(mock_console, show_hints=False)
+
+            # Verify CreateWatcherHostMaintenanceAuditStep called with correct params
+            mock_create_watcher_step.assert_called_once_with(
+                deployment=mock_deployment,
+                node="test-node",
+                disable_live_migration=disable_live_migration,
+                disable_cold_migration=disable_cold_migration,
+            )

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_maintenance.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_maintenance.py
@@ -151,7 +151,10 @@ class TestMicroCephActionStep:
 
 
 class TestCreateWatcherHostMaintenanceAuditStep:
-    def test_create_audit(self, mock_watcher_helper, mock_watcher_client):
+    def test_create_audit_default_migration_params(
+        self, mock_watcher_helper, mock_watcher_client
+    ):
+        """Test _create_audit with default migration parameters (both False)"""
         step = CreateWatcherHostMaintenanceAuditStep(Mock(), "fake-node")
         result = step._create_audit()
         assert result == mock_watcher_helper.create_audit.return_value
@@ -161,7 +164,36 @@ class TestCreateWatcherHostMaintenanceAuditStep:
         mock_watcher_helper.create_audit.assert_called_once_with(
             client=mock_watcher_client,
             template=mock_watcher_helper.get_enable_maintenance_audit_template.return_value,
-            parameters={"maintenance_node": "fake-node"},
+            parameters={
+                "maintenance_node": "fake-node",
+                "disable_live_migration": False,
+                "disable_cold_migration": False,
+            },
+        )
+
+    def test_create_audit_with_custom_migration_params(
+        self, mock_watcher_helper, mock_watcher_client
+    ):
+        """Test _create_audit with custom migration parameters."""
+        step = CreateWatcherHostMaintenanceAuditStep(
+            Mock(),
+            "fake-node",
+            disable_live_migration=True,
+            disable_cold_migration=False,
+        )
+        result = step._create_audit()
+        assert result == mock_watcher_helper.create_audit.return_value
+        mock_watcher_helper.get_enable_maintenance_audit_template.assert_called_once_with(
+            client=mock_watcher_client
+        )
+        mock_watcher_helper.create_audit.assert_called_once_with(
+            client=mock_watcher_client,
+            template=mock_watcher_helper.get_enable_maintenance_audit_template.return_value,
+            parameters={
+                "maintenance_node": "fake-node",
+                "disable_live_migration": True,
+                "disable_cold_migration": False,
+            },
         )
 
 


### PR DESCRIPTION
Add a flag `disable-migration` to `sunbeam cluster maintenance enable` command to allow disabling live/cold migration in a host maintenance event. This is based on the new feature of Watcher [2025.2](https://docs.openstack.org/releasenotes/watcher/2025.2.html#:~:text=The%20Host%20Maintenance%20strategy%20now%20supports,support%20scenarios%20where%20migration%20is%20disabled.) which was already added to watcher 2024.1 and 2025.1 rocks via SRU process.

This flag doesn't affect any current behavior. 
 
Usage:

- Without supplying, this will behave as normal (live migrate active instances, cold migrate inactive instances):
```
 sunbeam cluster maintenance enable compute-1 
```

- Disable live migration (cold migrate both active and inactive instances):
```
  sunbeam cluster maintenance enable compute-1 \
    --disable-migration=live 
```
 - Disable cold migration (live migrate active instances, ignore inactive instances): 
```
  sunbeam cluster maintenance enable compute-1 \
    --disable-migration=cold 
```

 - No migration (only stop active instances, ignore inactive instances):
```
  sunbeam cluster maintenance enable compute-1 \
    --disable-migration=both 
```
  or simplier: 
```
  sunbeam cluster maintenance enable compute-1 \
    --disable-migration 
```